### PR TITLE
Add basic CLI for Sprint 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,95 +2,58 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"net"
 	"os"
-	"strconv"
+	"strings"
 )
+
+const CLPrefix = ">>>"
+const ListenPort = 62000
 
 func main() {
 	fmt.Println("Kademlia node started!")
+	int, _ := net.InterfaceByName("eth0")
+	addrs, _ := int.Addrs()
+	fmt.Printf("IP Address: %s\n", addrs[0].(*net.IPNet).IP)
 	scanner := bufio.NewScanner(os.Stdin)
-	fmt.Print(">>> ")
-	for scanner.Scan() {
-		switch scanner.Text() {
-		case "test_listen":
-			// Listen to the IP and Port
-			listen("127.0.0.1", 62000)
-
-		case "test_send": // test_send <ip_address or hostname>
-			// Obtain the IP
-			fmt.Print("Introduce an IP: ")
-			scanner.Scan()
-			inputIP := scanner.Text()
-
-			// Obtain the Port
-			fmt.Print("Introduce a port number: ")
-			scanner.Scan()
-			inputPort, _ := strconv.Atoi(scanner.Text())
-
-			// Obtain the Message
-			fmt.Print("Introduce the message: ")
-			scanner.Scan()
-			inputMessage := scanner.Text()
-
-			send(inputIP, inputPort, []byte(inputMessage))
+	for {
+		fmt.Print(CLPrefix + " ")
+		if ! scanner.Scan() { break }
+		cmdLine := strings.Fields(scanner.Text())
+		cmd := ""
+		var args []string
+		if len(cmdLine) > 0 { cmd = cmdLine[0] }
+		if len(cmdLine) > 1 { args = cmdLine[1:] }
+		switch cmd {
+		case "udplisten":
+			conn, _ := net.ListenUDP("udp", &net.UDPAddr{Port: ListenPort})
+			fmt.Printf("Listening on port %d...\n", ListenPort)
+			buf := make([]byte, 1024)
+			_, addr, _ := conn.ReadFromUDP(buf)
+			fmt.Printf("Received message from %v: %s\n", addr.IP, buf)
+			conn.Close()
+		case "udpsend":
+			if len(args) < 2 {
+				fmt.Println("udpsend: Too few arguments given")
+				fmt.Println("usage: udpsend <dest> <msg>")
+				break
+			}
+			addr := net.UDPAddr {
+				IP:   net.ParseIP(args[0]),
+				Port: ListenPort,
+			}
+			conn, _ := net.DialUDP("udp", nil, &addr)
+			fmt.Fprintf(conn, args[1])
+			fmt.Println("Message sent!")
+			conn.Close()
 		case "put":
-			fmt.Println("put command received")
 		case "get":
-			fmt.Println("get command received")
+		case "":
 		case "exit":
 			os.Exit(0)
-		case "":
 		default:
-			fmt.Println("usage: [put/get/exit] ...")
+			fmt.Printf("Unsupported command: %s\n", cmd)
 		}
-		fmt.Print(">>> ")
 	}
-}
-
-func listen(ip string, port int) {
-	// Make the UDPAddr type
-	var nodeAddr net.UDPAddr
-	var netIP net.IP
-	netIP = net.ParseIP(ip) // Parse the IP to a series of bytes
-	nodeAddr = net.UDPAddr{netIP,port, ""} // Create the object
-	fmt.Printf("Listening in port %d\n", nodeAddr.Port)
-
-	// Make the node listen to the IP and port assigned
-	nodeCon, err := net.ListenUDP("udp", &nodeAddr)
-	if err != nil {
-		panic(err) // Stop the execution of this function
-	}
-
-	// Receive the message once a connection has been created
-	message := make([]byte, 1024)
-	n, _, _ := nodeCon.ReadFrom(message)
-
-	messageBuff := bytes.NewBuffer(message)
-	messageBuff.Truncate(n)
-
-	// Show the message
-	fmt.Printf("Message Received: %s\n", messageBuff)
-
-	// Close the connection
-	nodeCon.Close()
-}
-
-func send(ip string, port int, message []byte) {
-	// Create a nil connection
-	nodeCon, _ := net.ListenPacket("udp",":0")
-
-	// Make the UDPAddr type
-	var nodeAddr net.UDPAddr
-	var netIP net.IP
-	netIP = net.ParseIP(ip) // Parse the IP to a series of bytes
-	nodeAddr = net.UDPAddr{netIP,port, ""} // Create the object
-
-	// Send the message
-	nodeCon.WriteTo(message, &nodeAddr)
-
-	// Close the connection
-	nodeCon.Close()
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 )
 
 func main() {
@@ -12,6 +15,27 @@ func main() {
 	fmt.Print(">>> ")
 	for scanner.Scan() {
 		switch scanner.Text() {
+		case "test_listen":
+			// Listen to the IP and Port
+			listen("127.0.0.1", 62000)
+
+		case "test_send": // test_send <ip_address or hostname>
+			// Obtain the IP
+			fmt.Print("Introduce an IP: ")
+			scanner.Scan()
+			inputIP := scanner.Text()
+
+			// Obtain the Port
+			fmt.Print("Introduce a port number: ")
+			scanner.Scan()
+			inputPort, _ := strconv.Atoi(scanner.Text())
+
+			// Obtain the Message
+			fmt.Print("Introduce the message: ")
+			scanner.Scan()
+			inputMessage := scanner.Text()
+
+			send(inputIP, inputPort, []byte(inputMessage))
 		case "put":
 			fmt.Println("put command received")
 		case "get":
@@ -24,4 +48,49 @@ func main() {
 		}
 		fmt.Print(">>> ")
 	}
+}
+
+func listen(ip string, port int) {
+	// Make the UDPAddr type
+	var nodeAddr net.UDPAddr
+	var netIP net.IP
+	netIP = net.ParseIP(ip) // Parse the IP to a series of bytes
+	nodeAddr = net.UDPAddr{netIP,port, ""} // Create the object
+	fmt.Printf("Listening in port %d\n", nodeAddr.Port)
+
+	// Make the node listen to the IP and port assigned
+	nodeCon, err := net.ListenUDP("udp", &nodeAddr)
+	if err != nil {
+		panic(err) // Stop the execution of this function
+	}
+
+	// Receive the message once a connection has been created
+	message := make([]byte, 1024)
+	n, _, _ := nodeCon.ReadFrom(message)
+
+	messageBuff := bytes.NewBuffer(message)
+	messageBuff.Truncate(n)
+
+	// Show the message
+	fmt.Printf("Message Received: %s\n", messageBuff)
+
+	// Close the connection
+	nodeCon.Close()
+}
+
+func send(ip string, port int, message []byte) {
+	// Create a nil connection
+	nodeCon, _ := net.ListenPacket("udp",":0")
+
+	// Make the UDPAddr type
+	var nodeAddr net.UDPAddr
+	var netIP net.IP
+	netIP = net.ParseIP(ip) // Parse the IP to a series of bytes
+	nodeAddr = net.UDPAddr{netIP,port, ""} // Create the object
+
+	// Send the message
+	nodeCon.WriteTo(message, &nodeAddr)
+
+	// Close the connection
+	nodeCon.Close()
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,27 @@
 package main
 
-import "fmt"
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
 
 func main() {
-	fmt.Println("Hello, World!")
+	fmt.Println("Kademlia node started!")
+	scanner := bufio.NewScanner(os.Stdin)
+	fmt.Print(">>> ")
+	for scanner.Scan() {
+		switch scanner.Text() {
+		case "put":
+			fmt.Println("put command received")
+		case "get":
+			fmt.Println("get command received")
+		case "exit":
+			os.Exit(0)
+		case "":
+		default:
+			fmt.Println("usage: [put/get/exit] ...")
+		}
+		fmt.Print(">>> ")
+	}
 }


### PR DESCRIPTION
Supported commands:
- `udplisten`
- `udpsend`
- `exit`

Tested on multiple containers orchestrated by docker-compose. Still to test on the cluster.