### PR TITLE
Add RESTful interface

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,30 +5,19 @@
 # command line flags, in order to actually get any replicas started. That
 # command requires that a docker swarm is already running in order to function.
 
-version: "3"
 services:
-  kademliaNodes:
+  node:
     build: .
-    image: ghcr.io/matteocarnelos/kadlab:latest # Make sure your Docker image has this name.
+    image: ghcr.io/matteocarnelos/kadlab:latest
     stdin_open: true
     tty: true
     deploy:
-      mode: replicated
-      replicas: 5  
-#        resources:
-#           limits:
-#              cpus: "0.1"
-#              memory: 50M
+      replicas: 5
       restart_policy:
         condition: on-failure
-        delay: 5s
         max_attempts: 3
         window: 10s
-#    ports:
-#      - "4000:80"
-    networks:
-      - kademlia_network
-      
-networks:
-  kademlia_network:
-
+  terminal:
+    image: cosmintitei/bash-curl
+    stdin_open: true
+    tty: true

--- a/main.go
+++ b/main.go
@@ -7,8 +7,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"github.com/matteocarnelos/kadlab/kademlia"
+	"io/ioutil"
 	"math/rand"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -21,6 +23,63 @@ const ListenIP = "0.0.0.0"
 const ListenDelaySec = 5
 
 const CLIPrefix = ">>>"
+
+var kdm *kademlia.Kademlia
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	ip := strings.Split(r.RemoteAddr, ":")[0]
+	body, _ := ioutil.ReadAll(r.Body)
+	fmt.Printf("\n%s -> [%s %s %s] %s\n", ip, r.Method, r.URL, r.Proto, body)
+	var msg string
+	var code int
+	switch r.Method {
+	case "GET":
+		hash := strings.Split(r.URL.String(), "/")[2]
+		if len(hash) != 40 {
+			code = http.StatusBadRequest
+			msg = "Invalid hash, please provide a valid 160-bit data hash"
+			break
+		}
+		if content, ok := load(hash); ok {
+			code = http.StatusOK
+			msg = content
+		} else {
+			code = http.StatusNotFound
+			msg = "Object not found"
+		}
+	case "POST":
+		if len(body) > 255 {
+			code = http.StatusBadRequest
+			msg = "Invalid object size, maximum size is 255 bytes"
+			break
+		}
+		hash := store(string(body))
+		w.Header().Set("Location", "/objects/" + hash)
+		code = http.StatusCreated
+		msg = "Object stored!"
+	}
+	w.WriteHeader(code)
+	fmt.Fprintln(w, msg)
+	fmt.Printf("[%s %d %s] %s -> %s\n\n", r.Proto, code, http.StatusText(code), msg, ip)
+}
+
+func store(content string) string {
+	fmt.Println("Storing object...")
+	hash := kdm.Store([]byte(content))
+	fmt.Println("Object stored!")
+	fmt.Println()
+	return hash
+}
+
+func load(hash string) (string, bool) {
+	fmt.Println("Finding object...")
+	if data, ok := kdm.LookupData(hash); ok {
+		fmt.Println("Object found!")
+		fmt.Println()
+		return data.(string), true
+	}
+	return "", false
+}
 
 func main() {
 	iface, _ := net.InterfaceByName("eth0")
@@ -40,7 +99,7 @@ func main() {
 	fmt.Println()
 
 	me := kademlia.NewContact(id, ip.String())
-	kdm := kademlia.NewKademlia(me)
+	kdm = kademlia.NewKademlia(me)
 	kdm.StartListen(ListenIP, ListenPort)
 	delay := time.Duration(ListenDelaySec + rand.Intn(5))
 	time.Sleep(delay * time.Second)
@@ -56,6 +115,10 @@ func main() {
 		fmt.Println("Network joined!")
 		fmt.Println()
 	}
+
+	http.HandleFunc("/objects", handleRequest)
+	http.HandleFunc("/objects/", handleRequest)
+	go http.ListenAndServe(":80", nil)
 
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
@@ -77,10 +140,7 @@ func main() {
 				fmt.Println("Invalid object size, maximum size is 255 bytes")
 				break
 			}
-			fmt.Println("Storing object...")
-			hash := kdm.Store([]byte(args[0]))
-			fmt.Println("Object stored!")
-			fmt.Println()
+			hash := store(args[0])
 			fmt.Printf("Object hash: %s\n\n", hash)
 		case "get":
 			if len(args) != 1 {
@@ -89,16 +149,13 @@ func main() {
 				break
 			}
 			if len(args[0]) != 40 {
-				fmt.Println("Invalid hash, please provide a 160-bit data hash")
+				fmt.Println("Invalid hash, please provide a valid 160-bit data hash")
 				break
 			}
-			fmt.Println("Finding object...")
-			if data, ok := kdm.LookupData(args[0]); ok {
-				fmt.Println("Object found!")
-				fmt.Println()
-				fmt.Printf("Object content: %s\n\n", data)
+			if content, ok := load(args[0]); ok {
+				fmt.Printf("Object content: %s\n\n", content)
 			} else {
-				fmt.Println("Object not found")
+				fmt.Printf("Object not found\n\n")
 			}
 		case "":
 		case "exit":


### PR DESCRIPTION
Add RESTful application interface, as requested in U4

> A CLI interface may be useful for humans with terminals, but makes it difficult to integrate your storage network into web applications or other applica- tions. To remedy this, you will make every node also provide a RESTful HTTP interface with the following endpoints:
> * **POST /objects**: Each message sent to the endpoint must contain a data object in its HTTP body. If the operation is successful, the node must reply with `201 CREATED` containing both the contents of the uploaded object and a `Location: /objects/{hash}` header, where `{hash}` must be substituted for the hash of the uploaded object.
> * **GET /objects/{hash}**: The `{hash}` portion of the HTTP path is to be substituted for the hash of the object. A successful call should result in the contents of the object being responded with.